### PR TITLE
fix(memory-map): restrict zoom limits and pan boundaries to prevent map duplication

### DIFF
--- a/app/premium-gifts/map-memory/components/memory-map.tsx
+++ b/app/premium-gifts/map-memory/components/memory-map.tsx
@@ -873,6 +873,16 @@ export function MemoryMap({ mapData, mode = "active" }: MemoryMapProps) {
               streetViewControl: false,
               mapTypeControl: false,
               fullscreenControl: false,
+              minZoom: 3,
+              restriction: {
+                latLngBounds: {
+                  north: 85,
+                  south: -85,
+                  west: -180,
+                  east: 180,
+                },
+                strictBounds: true,
+              },
               styles: [
                 {
                   featureType: "poi",


### PR DESCRIPTION
fix(memory-map): restrict zoom limits and pan boundaries to prevent map duplication

Issue: https://github.com/nayanjyotigogoi/Tohfaah/issues/40